### PR TITLE
feat: currency formatter

### DIFF
--- a/__tests__/currency/parser.spec.ts
+++ b/__tests__/currency/parser.spec.ts
@@ -1,0 +1,51 @@
+import { fold } from "fp-ts/Either";
+import { currency } from "../../src/Currency";
+
+const typeError = new TypeError("invalid format");
+
+const cases = [
+  ["Rp 0", 0],
+  [NaN, typeError],
+  ["Rp 50.000", 50000],
+  [50000.67, 50001],
+  ["Rp 60.000,55", 60001],
+];
+
+const precisionCases = [
+  ["Rp 50.000,256", 2, 50000.26],
+  ["Rp 50.000,256", 4, 50000.256],
+  ["Rp50.000,256", 4, 50000.256],
+  ["Rp 100.000,25689", 4, 100000.2569],
+];
+
+describe("currency parse", () => {
+  const idrCurrency = currency();
+  test.each(cases)(
+    "parse %s",
+    // @ts-ignore
+    (a, b) => {
+      const value = fold(
+        (e) => e,
+        (val) => val
+      )(idrCurrency.parse(a));
+
+      expect(value).toStrictEqual(b);
+    }
+  );
+});
+
+describe("currency parse with precision", () => {
+  test.each(precisionCases)(
+    "parse %s",
+    // @ts-ignore
+    (a, b, c) => {
+      const currencyFormatter = currency(Number(b));
+      const value = fold(
+        (e) => e,
+        (val) => val
+      )(currencyFormatter.parse(a));
+
+      expect(value).toStrictEqual(c);
+    }
+  );
+});

--- a/docs-ts.json
+++ b/docs-ts.json
@@ -1,4 +1,10 @@
 {
   "srcDir": "src",
-  "exclude": ["src/index.ts", "src/internal/**/*.ts", "src/Number/**/*.ts"]
+  "exclude": [
+    "src/index.ts",
+    "src/locale/index.ts",
+    "src/locale/**/*.ts",
+    "src/internal/**/*.ts",
+    "src/Number/**/*.ts"
+  ]
 }

--- a/docs/modules/Currency/index.ts.md
+++ b/docs/modules/Currency/index.ts.md
@@ -1,0 +1,52 @@
+---
+title: Currency/index.ts
+nav_order: 1
+parent: Modules
+---
+
+## index overview
+
+Added in v0.0.1
+
+---
+
+<h2 class="text-delta">Table of contents</h2>
+
+- [Currency](#currency)
+  - [currency](#currency)
+
+---
+
+# Currency
+
+## currency
+
+currency formatter
+
+**Signature**
+
+```ts
+export declare const currency: (precision?: number) => ICurrencyFormat
+```
+
+**Example**
+
+```ts
+import { currency } from '@warungpintar/ninshu'
+import { fold } from 'fp-ts/Either'
+import { flow } from 'fp-ts/function'
+
+const formatter = currency()
+const moneyPrint = flow(
+  formatter.format,
+  fold((e) => e, console.log)
+)
+
+moneyPrint(5000)
+//> Rp 5000
+
+moneyPrint('hello world')
+//> [TypeError: invalid value]
+```
+
+Added in v0.0.1

--- a/docs/modules/Object.ts.md
+++ b/docs/modules/Object.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Object.ts
-nav_order: 1
+nav_order: 2
 parent: Modules
 ---
 

--- a/docs/modules/String.ts.md
+++ b/docs/modules/String.ts.md
@@ -1,6 +1,6 @@
 ---
 title: String.ts
-nav_order: 2
+nav_order: 3
 parent: Modules
 ---
 

--- a/src/Currency/index.ts
+++ b/src/Currency/index.ts
@@ -3,46 +3,86 @@
  */
 import * as E from "fp-ts/Either";
 import { Lazy, flow } from "fp-ts/function";
-import { lazy, isNumber, isNotNil } from "../internal";
+import { lazy, isNumber, isNotNil, isString } from "../internal";
 import { INumberFormat } from "../Number";
+import { id, ILocale } from "../locale";
 
 interface ICurrencyFormat extends INumberFormat {
   style: Lazy<"currency">;
 }
 
-const currencyFormatter = () =>
-  flow(
+const currencyFormatter = (locale: ILocale, precision = 0) => {
+  const { currency, delimiters } = locale;
+  const { symbol } = currency;
+  const { thousands, decimal } = delimiters;
+
+  const toStringFormat = flow(
+    (value: number) =>
+      `${symbol} ` +
+      value
+        .toFixed(precision)
+        .replace(/\./g, decimal)
+        .replace(/(\d)(?=(\d{3})+(?!\d))/g, `$1${thousands}`)
+  );
+
+  return flow(
     isNotNil,
     E.chain(isNumber),
-    E.chain((a) =>
-      E.right("Rp " + a.toFixed(0).replace(/(\d)(?=(\d{3})+(?!\d))/g, "$1."))
-    ),
+    E.chain((value) => E.right(toStringFormat(value))),
     E.mapLeft(() => new TypeError("invalid format"))
   );
+};
+
+const currencyParser = (locale: ILocale, precision = 0) => (input: unknown) => {
+  const { currency, delimiters } = locale;
+  const { symbol } = currency;
+  const { thousands, decimal } = delimiters;
+
+  if (E.isRight(isNumber(input)))
+    return E.right(Number((input as number).toFixed(precision)));
+
+  const fromStringFormat = flow(
+    (value: string) =>
+      +Number(
+        value
+          .replace(`${symbol}`, "")
+          .trim()
+          .replace(new RegExp(`\\${thousands}`, "g"), "")
+          .replace(new RegExp(`\\${decimal}`, "g"), ".")
+      ).toFixed(precision)
+  );
+
+  return flow(
+    isNotNil,
+    E.chain(isString),
+    E.map(fromStringFormat),
+    E.mapLeft(() => new TypeError("invalid format"))
+  )(input);
+};
 
 /**
  * currency formatter
- *
  * @example
  * import {currency} from '@warungpintar/ninshu';
  * import {fold} from 'fp-ts/Either';
  * import {flow} from 'fp-ts/function';
  *
  * const formatter = currency();
- * const moneyPrint = flow(formatter.format, fold(throw, console.log))
+ * const moneyPrint = flow(formatter.format, fold((e) =>  e, console.log))
  *
  * moneyPrint(5000)
  * //> Rp 5000
  *
  * moneyPrint("hello world")
- * //> Uncaught TypeError: invalid value
+ * //> [TypeError: invalid value]
  *
  * @since 0.0.1
  * @category Currency
  */
-export const currency = (): ICurrencyFormat => {
+export const currency = (precision = 0): ICurrencyFormat => {
   return {
     style: lazy("currency"),
-    format: currencyFormatter(),
+    format: currencyFormatter(id, precision),
+    parse: currencyParser(id, precision),
   };
 };

--- a/src/Number/index.ts
+++ b/src/Number/index.ts
@@ -4,7 +4,9 @@ import { Lazy } from "fp-ts/function";
 export type Unit = "currency" | "percent" | "decimal";
 
 export type Formatter<A, B> = (a: A) => E.Either<Error, B>;
+export type Parser<A, B> = (a: A) => E.Either<Error, B>;
 export interface INumberFormat {
   style: Lazy<Unit>;
-  readonly format: Formatter<any, string>;
+  readonly format: Formatter<unknown, string>;
+  readonly parse: Parser<unknown, number>;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./String";
 export * from "./Object";
+export * from "./Currency";

--- a/src/locale/id.ts
+++ b/src/locale/id.ts
@@ -1,0 +1,17 @@
+export const id = {
+  delimiters: {
+    thousands: ".",
+    decimal: ",",
+  },
+  abbreviations: {
+    thousand: "r",
+    million: "j",
+    billion: "m",
+    trillion: "t",
+  },
+  currency: {
+    symbol: "Rp",
+  },
+};
+
+export const idId = id;

--- a/src/locale/id.ts
+++ b/src/locale/id.ts
@@ -4,8 +4,8 @@ export const id = {
     decimal: ",",
   },
   abbreviations: {
-    thousand: "r",
-    million: "j",
+    thousand: "rb",
+    million: "jt",
     billion: "m",
     trillion: "t",
   },

--- a/src/locale/index.ts
+++ b/src/locale/index.ts
@@ -1,0 +1,17 @@
+export * from "./id";
+
+export interface ILocale {
+  delimiters: {
+    thousands: string;
+    decimal: string;
+  };
+  abbreviations: {
+    thousand: string;
+    million: string;
+    billion: string;
+    trillion: string;
+  };
+  currency: {
+    symbol: string;
+  };
+}


### PR DESCRIPTION
## Summary
add currency formatter with only id-ID locale support

### Example

```ts
import {currency} from '@warungpintar/ninshu';
import {fold} from 'fp-ts/Either';
import {flow} from 'fp-ts/function';

const formatter = currency(2); // precision 2
const parseMoney = flow(formatter.parse, fold(e) => e, console.log)
const moneyPrint = flow(formatter.format, fold((e) =>  e, console.log))
 
moneyPrint(5000)
//> Rp 5000

moneyPrint(100000.268)
//> Rp 100.000,27
 
moneyPrint("hello world")
//> [TypeError: invalid value]

parseMoney("Rp 10.000")
//> 10000
```